### PR TITLE
fix MissingForegroundServiceTypeException

### DIFF
--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -80,7 +80,7 @@ configurations {
 android {
     namespace 'net.kdt.pojavlaunch'
 
-    compileSdk = 33
+    compileSdk = 34
 
     lintOptions {
         abortOnError false
@@ -104,8 +104,8 @@ android {
 
     defaultConfig {
         applicationId "net.kdt.pojavlaunch.firefly"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdkVersion 23
+        targetSdkVersion 34
         versionCode getDateSeconds()
         versionName getVersionName()
         multiDexEnabled true //important
@@ -215,7 +215,7 @@ android {
         prefab true
     }
 
-    buildToolsVersion = '33.0.2'
+    buildToolsVersion = '34.0.0'
 }
 
 dependencies {

--- a/app_pojavlauncher/src/main/AndroidManifest.xml
+++ b/app_pojavlauncher/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
         android:name=".PojavApplication"
@@ -119,10 +120,17 @@
             </intent-filter>
         </provider>
 
-        <service android:name=".services.ProgressService" />
+        <service 
+            android:name=".services.ProgressService" 
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
+            
         <service
             android:name=".services.GameService"
-            android:process=":game" />
+            android:process=":game"
+            android:foregroundServiceType="specialUse"
+            android:exported="false" />
+        
     </application>
     <queries>
         <package android:name="net.kdt.pojavlaunch.ffmpeg"/>


### PR DESCRIPTION
When I was using the launcher to start the game today, I got the following error:
![IMG20240322191546](https://github.com/Vera-Firefly/Pojav-Glow-Worm/assets/62003611/9590c587-e91b-4e72-9c57-b805d03bb00e)

Its log looks like this:
java.lang.RuntimeException: Unable to start service net.kdt.pojavlaunch.services.ProgressService@a16575e with Intent { cmp=net.kdt.pojavlaunch.firefly.debug/net.kdt.pojavlaunch.services.ProgressService }: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{e38a45d 23873:net.kdt.pojavlaunch.firefly.debug:launcher/u0a137} targetSDK=33	at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:5410)	at android.app.ActivityThread.-$$Nest$mhandleServiceArgs(Unknown Source:0)	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2699)	at android.os.Handler.dispatchMessage(Handler.java:108)	at android.os.Looper.loopOnce(Looper.java:226)	at android.os.Looper.loop(Looper.java:328)	at android.app.ActivityThread.main(ActivityThread.java:9220)	at java.lang.reflect.Method.invoke(Native Method)	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:586)	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)Caused by: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{e38a45d 23873:net.kdt.pojavlaunch.firefly.debug:launcher/u0a137} targetSDK=33	at android.app.MissingForegroundServiceTypeException$1.createFromParcel(MissingForegroundServiceTypeException.java:53)	at android.app.MissingForegroundServiceTypeException$1.createFromParcel(MissingForegroundServiceTypeException.java:49)	at android.os.Parcel.readParcelableInternal(Parcel.java:4884)	at android.os.Parcel.readParcelable(Parcel.java:4866)	at android.os.Parcel.createExceptionOrNull(Parcel.java:3066)	at android.os.Parcel.createException(Parcel.java:3055)	at android.os.Parcel.readException(Parcel.java:3038)	at android.os.Parcel.readException(Parcel.java:2980)	at android.app.IActivityManager$Stub$Proxy.setServiceForeground(IActivityManager.java:7457)	at android.app.Service.startForeground(Service.java:775)	at net.kdt.pojavlaunch.services.ProgressService.onStartCommand(ProgressService.java:67)	at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:5392)	... 9 more

I checked the official documentation of Android and found that my phone had upgraded to Android 14 by itself, and Android 14 has new constraints on the front desk service, see: https://developer.android.google.cn/about/versions/14/behavior-changes-14?hl=en

So I fixed the bug, like this